### PR TITLE
Add plugin hooks

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,18 +6,18 @@ echo "~~~ :node: Installing node.js"
 
 echo "--- Installing nvm"
 
-nvm_installation_dir="$(mktemp -d)"
-touch "$nvm_installation_dir/.automattic-nvm-dir-marker"
+NVM_DIR="$(mktemp -d)"
+export NVM_DIR
+touch "$NVM_DIR/.automattic-nvm-dir-marker"
 
 # Store the installation directory in meta-data so that we can uninstall it later in the pre-exit hook.
-buildkite-agent meta-data set "automattic-nvm-installation-dir" "$nvm_installation_dir"
-echo "Installing nvm in $nvm_installation_dir"
+buildkite-agent meta-data set "automattic-nvm-installation-dir" "$NVM_DIR"
+echo "Installing nvm in $NVM_DIR"
 
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | \
-    PROFILE=/dev/null NVM_DIR="${nvm_installation_dir}" bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash
 
 # shellcheck source=/dev/null
-source "$nvm_installation_dir/nvm.sh"
+source "$NVM_DIR/nvm.sh"
 
 echo "--- Installing node.js"
 install_args=("--no-progress")
@@ -30,5 +30,3 @@ fi
 nvm install "${install_args[@]}"
 
 echo "--- Using node $(nvm current)"
-
-unset nvm_installation_dir

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-echo "~~~ :node: Installing node.js"
+echo "--- :node: Installing node.js"
 
-echo "--- Installing nvm"
+echo "~~~ Installing nvm"
 
 NVM_DIR="$(mktemp -d)"
 export NVM_DIR
@@ -19,7 +19,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFI
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh"
 
-echo "--- Installing node.js"
+echo "~~~ Installing node.js"
 install_args=("--no-progress")
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
     echo "Installing node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
@@ -29,4 +29,4 @@ else
 fi
 nvm install "${install_args[@]}"
 
-echo "--- Using node $(nvm current)"
+echo "~~~ Using node $(nvm current)"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,7 +17,7 @@ echo "Installing nvm in $NVM_DIR"
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash
 
 # shellcheck source=/dev/null
-source "$NVM_DIR/nvm.sh"
+source "$NVM_DIR/nvm.sh" --no-use
 
 echo "~~~ Installing node.js"
 install_args=("--no-progress")

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "~~~ :node: Installing node.js"
+
+echo "--- Installing nvm"
+
+nvm_installation_dir="$(mktemp -d)"
+touch "$nvm_installation_dir/.automattic-nvm-dir-marker"
+
+# Store the installation directory in meta-data so that we can uninstall it later in the pre-exit hook.
+buildkite-agent meta-data set "automattic-nvm-installation-dir" "$nvm_installation_dir"
+echo "Installing nvm in $nvm_installation_dir"
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | \
+    PROFILE=/dev/null NVM_DIR="${nvm_installation_dir}" bash
+
+# shellcheck source=/dev/null
+source "$nvm_installation_dir/nvm.sh"
+
+echo "--- Installing node.js"
+install_args=("--no-progress")
+if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
+    echo "Installing node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
+    install_args+=("${BUILDKITE_PLUGIN_NVM_VERSION}")
+else
+    echo "Installing node.js version specified in the .nvmrc file"
+fi
+nvm install "${install_args[@]}"
+
+echo "--- Using node $(nvm current)"
+
+unset nvm_installation_dir

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,9 +5,10 @@ set -euo pipefail
 nvm_installation_dir=$(buildkite-agent meta-data get "automattic-nvm-installation-dir")
 # if file $nvm_dir/.automattic-nvm-dir-marker" exists
 if [[ -f "$nvm_installation_dir/.automattic-nvm-dir-marker" ]]; then
-    echo "--- :node: Uninstalling node.js"
+    echo "~~~ :node: Uninstalling node.js"
+    echo "Removing $nvm_installation_dir"
     rm -rf "$nvm_installation_dir"
 else
-    echo "--- :node: No node.js installation to uninstall"
+    echo "~~~ :node: No node.js installation to uninstall"
     echo "The directory is not created by the automattic/nvm-buildkite-plugin: $nvm_installation_dir"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+nvm_installation_dir=$(buildkite-agent meta-data get "automattic-nvm-installation-dir")
+# if file $nvm_dir/.automattic-nvm-dir-marker" exists
+if [[ -f "$nvm_installation_dir/.automattic-nvm-dir-marker" ]]; then
+    echo "--- :node: Uninstalling node.js"
+    rm -rf "$nvm_installation_dir"
+else
+    echo "--- :node: No node.js installation to uninstall"
+    echo "The directory is not created by the automattic/nvm-buildkite-plugin: $nvm_installation_dir"
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: Set up node.js environment using nvm
+name: NVM
 description: Annotates the build with a file count
 author: https://github.com/automattic
 requirements: []


### PR DESCRIPTION
The plugin configures the running pipeline with the specified node version: either via a `.nvmrc` file or the optional `version` plugin configuration. This plugin works on all platforms without any special setup on the buildkite agents.

## How it works

The plugin uses a `pre-command` hook to install nvm.sh and the specified node version in a temporary directory. `nvm` automatically switches to the installed node version. Since the hook is `source`-ed, [the `PATH` updated by nvm](https://github.com/nvm-sh/nvm/blob/v0.39.4/nvm.sh#L3635-L3646) continues to take effect in the running pipeline's process that means the pipeline gets the node version it asks for.

## Next step

After this PR is merged and the first version of this plugin is released, I'll delete [the `nvm_install` utility](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/2.18.2/bin/nvm_install). Because that utility does not work. The `nvm_install` utility is called as a shell script, the node environment is only changed within the `nvm_install` process, not the pipeline process that calls it.