### PR TITLE
Fix issues when used in macOS pipelines

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,28 @@
 steps:
   - command: make validate
-  - label: ":node: Validate {{ matrix }}"
-    command: .buildkite/verify_node.sh {{ matrix }}
+
+  - label: ":node: Validate {{ matrix.node }} via version property"
+    command: .buildkite/verify_node.sh {{ matrix.node }}
     plugins:
       - automattic/nvm#${BUILDKITE_COMMIT}:
-          version: "{{ matrix }}"
+          version: "{{ matrix.node }}"
+    env:
+      IMAGE_ID: xcode-14.3.1
+    agents:
+      queue: "{{ matrix.queue }}"
     matrix:
-      # node v18 and later don't work on the current build agent.
-      # Once we switch to a newer OS for the default agent, we can add more node
-      # versions here. See https://github.com/nvm-sh/nvm/issues/2972
-      - v17
-      - v16
+      setup:
+        node:
+          # node v18 and later don't work on the current build agent.
+          # Once we switch to a newer OS for the default agent, we can add more node
+          # versions here. See https://github.com/nvm-sh/nvm/issues/2972
+          - v17
+          - v16
+        queue:
+          - mac
+          - default
+
+  - label: ":node: Do nothing when no .nvmrc and no node version specified"
+    command: echo noop
+    plugins:
+      - automattic/nvm#${BUILDKITE_COMMIT}

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -4,6 +4,16 @@ set -euo pipefail
 
 echo "~~~ Installing nvm"
 
+[[ -f .nvmrc || -n "${BUILDKITE_PLUGIN_NVM_VERSION:-}" ]] || {
+    echo "No .nvmrc or node version specified, skipping nvm installation"
+    return
+}
+
+[[ -z "${IS_VM_HOST:-}" ]] || {
+    echo "No need to install nvm on the host, skipping nvm installation"
+    return
+}
+
 NVM_DIR="$(mktemp -dt automattic-nvm-XXXXXXXX)"
 export NVM_DIR
 touch "$NVM_DIR/.automattic-nvm-dir-marker"


### PR DESCRIPTION
Fixes #5 #6.

This PR adds a couple of test steps to the pipeline:
1. Verify the plugin works on Automattic `mac` and `default` agents.
2. Verify the plugin does not report an error when there is no .nvmrc file nor a node version specified.