### PR TITLE
Update CHANGELOG for 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 0.2.1
+
+### Bug Fixes
+
+* Fix issue in macOS when a script tried to `source` the `$NVM_DIR` [#9]
+
 ## 0.2.0
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - automattic/nvm#0.2.0:
+      - automattic/nvm#0.2.1:
           version: 'v18'
 ```
 


### PR DESCRIPTION
I verified #9 unblocks using the plugin in gutenberg-mobile: [failing build](https://buildkite.com/automattic/gutenberg-mobile/builds/7269) before #9, [passing build](https://buildkite.com/automattic/gutenberg-mobile/builds/7271) after.

Time to ship a new version. Thanks a lot @crazytonyli for the quick fixes!