### PR TITLE
Add an option to pass extra arguments to curl commands

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,3 +43,19 @@ steps:
         queue:
           - mac
           - default
+
+  - label: ":node: [Test] curlrc option"
+    command: cd tests/dummy && npm install
+    plugins:
+      - automattic/nvm#${BUILDKITE_COMMIT}:
+          version: v17
+          curlrc: --verbose
+    env:
+      IMAGE_ID: xcode-14.3.1
+    agents:
+      queue: "{{ matrix.queue }}"
+    matrix:
+      setup:
+        queue:
+          - mac
+          - default

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,11 @@ steps:
 
       echo "--- Verify curl output is NOT verbose"
       curl -s https://google.com
+
+      if curl -s https://google.com 2>&1 | grep -F HTTP; then
+        echo "curl command that is invoked in pipeline script should not be verbose"
+        exit 1
+      fi
     plugins:
       - automattic/nvm#${BUILDKITE_COMMIT}:
           version: v17

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,14 @@ steps:
           - default
 
   - label: ":node: [Test] curlrc option"
-    command: cd tests/dummy && npm install
+    command: |
+      set -euo pipefail
+
+      echo "--- Verify node installation"
+      cd tests/dummy && npm install
+
+      echo "--- Verify curl output is NOT verbose"
+      curl -s https://google.com
     plugins:
       - automattic/nvm#${BUILDKITE_COMMIT}:
           version: v17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 0.3.0
+
+### New Features
+
+* Add a new option `curlrc` which allows pipelines to pass extra arguments to curl commands.
+
 ## 0.2.1
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ steps:
 
 The node.js version [that nvm supports](https://github.com/nvm-sh/nvm#nvmrc). If it's not set, the project's `.nvmrc` file will be used.
 
+### `curlrc` (Optional, string)
+
+Content of [a curlrc file](https://curl.se/docs/manpage.html#-K). This option can be used to pass extra command line arguments to _all curl commands_. For example `--http1.1` makes nvm–which invokes curl commands—use HTTP1.1 protocol.
+
 ## Contributing
 
 1. Fork the repo

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - automattic/nvm#0.2.1:
+      - automattic/nvm#0.3.0:
           version: 'v18'
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The node.js version [that nvm supports](https://github.com/nvm-sh/nvm#nvmrc). If
 
 ### `curlrc` (Optional, string)
 
-Content of [a curlrc file](https://curl.se/docs/manpage.html#-K). This option can be used to pass extra command line arguments to _all curl commands_. For example `--http1.1` makes nvm–which invokes curl commands—use HTTP1.1 protocol.
+Content of [a `.curlrc` file](https://curl.se/docs/manpage.html#-K). This option can be used to pass extra command line arguments to _all curl commands_. For example `--http1.1` makes nvm–which invokes curl commands—use HTTP1.1 protocol.
 
 ## Contributing
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -22,6 +22,7 @@ export NVM_DIR
 touch "$NVM_DIR/.automattic-nvm-dir-marker"
 
 # Pass the user specified .curlrc file content to all curl commands.
+original_curl_home="${CURL_HOME:-}"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_CURLRC:-} ]]; then
     export CURL_HOME="$NVM_DIR"
     echo "${BUILDKITE_PLUGIN_NVM_CURLRC}" > "$CURL_HOME/.curlrc"
@@ -55,3 +56,9 @@ fi
 
 echo "Verify that node (version $(node --version)) can be used"
 test "$(echo 'console.log("Hello node.js")' | node -)" == "Hello node.js"
+
+# Reset or remove CURL_HOME env var
+unset CURL_HOME
+if [[ -n ${original_curl_home:-} ]]; then
+    export CURL_HOME="${original_curl_home}"
+fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -21,6 +21,12 @@ NVM_DIR=$(readlink -fn "$NVM_DIR")
 export NVM_DIR
 touch "$NVM_DIR/.automattic-nvm-dir-marker"
 
+# Pass the user specified .curlrc file content to all curl commands.
+if [[ -n ${BUILDKITE_PLUGIN_NVM_CURLRC:-} ]]; then
+    export CURL_HOME="$NVM_DIR"
+    echo "${BUILDKITE_PLUGIN_NVM_CURLRC}" > "$CURL_HOME/.curlrc"
+fi
+
 # Store the installation directory in meta-data so that we can uninstall it later in the pre-exit hook.
 buildkite-agent meta-data set "automattic-nvm-installation-dir" "$NVM_DIR"
 echo "Installing nvm in $NVM_DIR"


### PR DESCRIPTION
## Issue

Sometimes on CI, we got the following error (here is [an example](https://buildkite.com/automattic/gutenberg-mobile/builds/7737#018b8633-2b27-4ed4-8bee-875f26abad94/338-343)) from installing node:
> curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)

Even though the error is originated from nvm, but it doesn't appear to be an issue in nvm. [The same issue appears in n too](https://www.github.com/tj/n/issues/784#issue-1905460979), which is a similar tool as nvm. And, it's likely an issue in [the node.js package CDN (https://nodejs.org/dist)](https://www.github.com/tj/n/issues/784#issuecomment-1738813821).

## Changes

Since "HTTP2" is mentioned in the error message, I thought it might be worthy trying using HTTP1.1 protocol to download node.js packages.

nvm uses curl to perform HTTP requests and downloads. However, it doesn't provide an option to customize curl commands. I hoped there is a magic environment variable, like `CURL_EXTRA_OPTS`, that curl supports as a way to pass extra arguments. But that doesn't exists too. The only way I can find in curl is using [a curlrc file](https://curl.se/docs/manpage.html#-K).

As you can see in the linked document, curl looks for this rc file at `$CURL_HOME/.curlrc`. This PR takes advantage of that mechanism to pass extra arguments (i.e. `--http1.1`) to nvm's curl commands, by writing the user specified curl options content to a curlrc file at the same directory where nvm is installed and setting the nvm directory as `CURL_HOME`.

## Test

I have added a test step to the pipeline, which passes a `--verbose` option via the new `curlrc` option. You can checkout the CI step output (the installing node part specifically) and see the option did get picked up by curl.