### PR TITLE
Prefix `pre-command` hook messages with `:node:` 

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-echo "~~~ Installing nvm"
+echo "~~~ :node: Installing nvm"
 
 [[ -f .nvmrc || -n "${BUILDKITE_PLUGIN_NVM_VERSION:-}" ]] || {
     echo "No .nvmrc or node version specified, skipping nvm installation"
@@ -37,7 +37,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFI
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use
 
-echo "~~~ Installing node.js"
+echo "~~~ :node: Installing node.js"
 install_args=("--no-progress")
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
     echo "Installing node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
@@ -47,7 +47,7 @@ else
 fi
 nvm install "${install_args[@]}"
 
-echo "~~~ Activate node"
+echo "~~~ :node: Activate node"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
     nvm use "${BUILDKITE_PLUGIN_NVM_VERSION}"
 else

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -37,7 +37,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFI
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use
 
-echo "~~~ :node: Installing node.js"
+echo "~~~ :node: Installing Node.js"
 install_args=("--no-progress")
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
     echo "Installing node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
@@ -47,14 +47,14 @@ else
 fi
 nvm install "${install_args[@]}"
 
-echo "~~~ :node: Activating node"
+echo "~~~ :node: Activating Node.js"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
     nvm use "${BUILDKITE_PLUGIN_NVM_VERSION}"
 else
     nvm use
 fi
 
-echo "Verifying that node (version $(node --version)) can be used..."
+echo "Verifying that Node.js (version $(node --version)) can be used..."
 test "$(echo 'console.log("Hello node.js")' | node -)" == "Hello node.js"
 
 # Reset or remove CURL_HOME env var
@@ -63,4 +63,4 @@ if [[ -n ${original_curl_home:-} ]]; then
     export CURL_HOME="${original_curl_home}"
 fi
 
-echo "nvm and node successfully set up."
+echo "Node.js and nvm successfully set up."

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -62,3 +62,5 @@ unset CURL_HOME
 if [[ -n ${original_curl_home:-} ]]; then
     export CURL_HOME="${original_curl_home}"
 fi
+
+echo "nvm and node successfully set up."

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -47,14 +47,14 @@ else
 fi
 nvm install "${install_args[@]}"
 
-echo "~~~ :node: Activate node"
+echo "~~~ :node: Activating node"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
     nvm use "${BUILDKITE_PLUGIN_NVM_VERSION}"
 else
     nvm use
 fi
 
-echo "Verify that node (version $(node --version)) can be used"
+echo "Verifying that node (version $(node --version)) can be used..."
 test "$(echo 'console.log("Hello node.js")' | node -)" == "Hello node.js"
 
 # Reset or remove CURL_HOME env var


### PR DESCRIPTION
This is to make them consistent with the `pre-exit` hook.

I've been looking at CI logs quite a bit today, and notice this minor inconsistency. Current state is:

![image](https://github.com/user-attachments/assets/3d3729da-e182-45d3-9862-031e650472a0)

Notice how the `pre-exit` at the bottom has the Node custom emoji, but not the steps at the top from the `pre-command`.

Now, I kind like using the emojis, but it might also be that it'll become too distracting in the logs. If that's the worry, then I'd say we should remove the `:node:` prefix from the `pre-exit` hook instead. 

What do you think?