### PR TITLE
Use Node.js instead of node.js or node where appropriate

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,16 +13,17 @@ steps:
     matrix:
       setup:
         node:
-          # node v18 and later don't work on the current build agent.
-          # Once we switch to a newer OS for the default agent, we can add more node
-          # versions here. See https://github.com/nvm-sh/nvm/issues/2972
+          # Node.js v18 and later don't work on the current build agent.
+          # Once we switch to a newer OS for the default agent, we can add more
+          # Node.js versions here.
+          # See https://github.com/nvm-sh/nvm/issues/2972
           - v17
           - v16
         queue:
           - mac
           - default
 
-  - label: ":node: Do nothing when no .nvmrc and no node version specified"
+  - label: ":node: Do nothing when no .nvmrc and no Node.js version specified"
     command: echo noop
     plugins:
       - automattic/nvm#${BUILDKITE_COMMIT}
@@ -48,7 +49,7 @@ steps:
     command: |
       set -euo pipefail
 
-      echo "--- Verify node installation"
+      echo "--- Verify Node.js installation"
       cd tests/dummy && npm install
 
       echo "--- Verify curl output is NOT verbose"

--- a/.buildkite/verify_node.sh
+++ b/.buildkite/verify_node.sh
@@ -2,19 +2,19 @@
 
 set -euo pipefail
 
-echo "--- :node: Current node version is $(node --version)"
+echo "--- :node: Current Node.js version is $(node --version)"
 
 echo "NVM_DIR is: $NVM_DIR"
 
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use
 
-echo "Checking if the active node version is '$1'"
+echo "Checking if the active Node.js version is '$1'"
 
 expected_version=$(nvm version-remote "$1")
-echo "'$1' is resolved to the node version $expected_version"
+echo "'$1' is resolved to the Node.js version $expected_version"
 
 current_version=$(nvm current)
-echo "Currently activated node version is $current_version"
+echo "Currently activated Node.js version is $current_version"
 
 test "$current_version" == "$expected_version"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Buildkite Plugin
 
-Set up node.js environment using [nvm](https://github.com/nvm-sh/nvm).
+Set up Node.js environment using [nvm](https://github.com/nvm-sh/nvm).
 
 ## Example
 
@@ -18,7 +18,7 @@ steps:
 
 ### `version` (Optional, string)
 
-The node.js version [that nvm supports](https://github.com/nvm-sh/nvm#nvmrc). If it's not set, the project's `.nvmrc` file will be used.
+The Node.js version [that nvm supports](https://github.com/nvm-sh/nvm#nvmrc). If it's not set, the project's `.nvmrc` file will be used.
 
 ### `curlrc` (Optional, string)
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -40,10 +40,10 @@ source "$NVM_DIR/nvm.sh" --no-use
 echo "~~~ :node: Installing Node.js"
 install_args=("--no-progress")
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
-    echo "Installing node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
+    echo "Installing Node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
     install_args+=("${BUILDKITE_PLUGIN_NVM_VERSION}")
 else
-    echo "Installing node.js version specified in the .nvmrc file"
+    echo "Installing Node.js version specified in the .nvmrc file"
 fi
 nvm install "${install_args[@]}"
 
@@ -55,7 +55,7 @@ else
 fi
 
 echo "Verifying that Node.js (version $(node --version)) can be used..."
-test "$(echo 'console.log("Hello node.js")' | node -)" == "Hello node.js"
+test "$(echo 'console.log("Hello Node.js")' | node -)" == "Hello Node.js"
 
 # Reset or remove CURL_HOME env var
 unset CURL_HOME

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -5,7 +5,7 @@ set -euo pipefail
 echo "~~~ :node: Installing nvm"
 
 [[ -f .nvmrc || -n "${BUILDKITE_PLUGIN_NVM_VERSION:-}" ]] || {
-    echo "No .nvmrc or node version specified, skipping nvm installation"
+    echo "No .nvmrc or Node.js version specified, skipping nvm installation"
     return
 }
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,10 +5,10 @@ set -euo pipefail
 nvm_installation_dir=$(buildkite-agent meta-data get "automattic-nvm-installation-dir")
 # if file $nvm_dir/.automattic-nvm-dir-marker" exists
 if [[ -f "$nvm_installation_dir/.automattic-nvm-dir-marker" ]]; then
-    echo "~~~ :node: Uninstalling node.js"
+    echo "~~~ :node: Uninstalling Node.js"
     echo "Removing $nvm_installation_dir"
     rm -rf "$nvm_installation_dir"
 else
-    echo "~~~ :node: No node.js installation to uninstall"
+    echo "~~~ :node: No Node.js installation to uninstall"
     echo "The directory is not created by the automattic/nvm-buildkite-plugin: $nvm_installation_dir"
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: NVM
-description: Sets up node.js environment using nvm
+description: Sets up Node.js environment using nvm
 author: https://github.com/automattic
 requirements: []
 configuration:


### PR DESCRIPTION
I was going to ship a new version, then I thought I ought to test the plugin in a repo to see how the logs look, then I realized the unit tests already do that 💪 

Looking at the unit tests logs, I noticed a "node.js" that looked out of place with the other (properly capitalized) "Node.js" logs. See bottom of the screenshot below:

<img width="465" alt="image" src="https://github.com/user-attachments/assets/c51846c8-2707-422e-8c52-a62e2f31616d" />

I decided to grep the codebase for "node" and "node.js", via `g grep -E 'node|node\.js'`, and addressed them.

[Final result](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/69):

<table>
<tr>
<td>

![image](https://github.com/user-attachments/assets/14921175-da0b-471a-838c-a139976d3a7a)

</td>
<td>

![image](https://github.com/user-attachments/assets/05c5e246-912e-4ae7-ad38-0f2c1dd4ac81)


</td>
</tr>
</table>