### PR TITLE
Remove usage of Buildkite meta-data to delete `NVM_DIR`

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -14,12 +14,15 @@ echo "~~~ :node: Installing nvm"
     return
 }
 
-NVM_DIR="$(mktemp -dt automattic-nvm-XXXXXXXX)"
+# Use a deterministic directory path based on BUILDKITE_JOB_ID
+TEMP_DIR="${TMPDIR:-/tmp}"
+NVM_DIR="${TEMP_DIR}/automattic-nvm-${BUILDKITE_JOB_ID}"
+mkdir -p "$NVM_DIR"
+
 # Make sure the path is a real path, to support scripts in macOS that source $NVM_DIR.
 # More details at https://github.com/Automattic/nvm-buildkite-plugin/pull/9
 NVM_DIR=$(readlink -fn "$NVM_DIR")
 export NVM_DIR
-touch "$NVM_DIR/.automattic-nvm-dir-marker"
 
 # Pass the user specified .curlrc file content to all curl commands.
 original_curl_home="${CURL_HOME:-}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,8 +15,7 @@ echo "~~~ :node: Installing nvm"
 }
 
 # Use a deterministic directory path based on BUILDKITE_JOB_ID
-TEMP_DIR="${TMPDIR:-/tmp}"
-NVM_DIR="${TEMP_DIR}/automattic-nvm-${BUILDKITE_JOB_ID}"
+NVM_DIR="${TMPDIR:-/tmp}/automattic-nvm-${BUILDKITE_JOB_ID}"
 mkdir -p "$NVM_DIR"
 
 # Make sure the path is a real path, to support scripts in macOS that source $NVM_DIR.

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -28,8 +28,6 @@ if [[ -n ${BUILDKITE_PLUGIN_NVM_CURLRC:-} ]]; then
     echo "${BUILDKITE_PLUGIN_NVM_CURLRC}" > "$CURL_HOME/.curlrc"
 fi
 
-# Store the installation directory in meta-data so that we can uninstall it later in the pre-exit hook.
-buildkite-agent meta-data set "automattic-nvm-installation-dir" "$NVM_DIR"
 echo "Installing nvm in $NVM_DIR"
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,10 +3,8 @@
 set -euo pipefail
 
 # Use the same deterministic directory path as in pre-command
-TEMP_DIR="${TMPDIR:-/tmp}"
-nvm_dir="${TEMP_DIR}/automattic-nvm-${BUILDKITE_JOB_ID}"
+nvm_dir="${TMPDIR:-/tmp}/automattic-nvm-${BUILDKITE_JOB_ID}"
 
-# Check if the directory exists and has our marker file
 if [[ -d "$nvm_dir" ]]; then
     echo "~~~ :node: Uninstalling Node.js"
     echo "Removing $nvm_dir"
@@ -14,5 +12,5 @@ if [[ -d "$nvm_dir" ]]; then
     echo "Node.js successfully removed."
 else
     echo "~~~ :node: No Node.js installation to uninstall"
-    echo "Directory does not exist or was not created by this plugin: $nvm_dir"
+    echo "Directory not found: $nvm_dir"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,13 +2,17 @@
 
 set -euo pipefail
 
-nvm_installation_dir=$(buildkite-agent meta-data get "automattic-nvm-installation-dir")
-# if file $nvm_dir/.automattic-nvm-dir-marker" exists
-if [[ -f "$nvm_installation_dir/.automattic-nvm-dir-marker" ]]; then
+# Use the NVM_DIR environment variable set by the pre-command hook
+nvm_dir="${NVM_DIR:-}"
+
+# Only remove directories that have our marker file to ensure we only clean up
+# directories created by our plugin
+if [[ -d "$nvm_dir" && -f "$nvm_dir/.automattic-nvm-dir-marker" ]]; then
     echo "~~~ :node: Uninstalling Node.js"
-    echo "Removing $nvm_installation_dir"
-    rm -rf "$nvm_installation_dir"
+    echo "Removing $nvm_dir"
+    rm -rf "$nvm_dir"
+    echo "Node.js successfully removed."
 else
     echo "~~~ :node: No Node.js installation to uninstall"
-    echo "The directory is not created by the automattic/nvm-buildkite-plugin: $nvm_installation_dir"
+    echo "NVM_DIR is not set or directory does not exist: $nvm_dir"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,17 +2,17 @@
 
 set -euo pipefail
 
-# Use the NVM_DIR environment variable set by the pre-command hook
-nvm_dir="${NVM_DIR:-}"
+# Use the same deterministic directory path as in pre-command
+TEMP_DIR="${TMPDIR:-/tmp}"
+nvm_dir="${TEMP_DIR}/automattic-nvm-${BUILDKITE_JOB_ID}"
 
-# Only remove directories that have our marker file to ensure we only clean up
-# directories created by our plugin
-if [[ -d "$nvm_dir" && -f "$nvm_dir/.automattic-nvm-dir-marker" ]]; then
+# Check if the directory exists and has our marker file
+if [[ -d "$nvm_dir" ]]; then
     echo "~~~ :node: Uninstalling Node.js"
     echo "Removing $nvm_dir"
     rm -rf "$nvm_dir"
     echo "Node.js successfully removed."
 else
     echo "~~~ :node: No Node.js installation to uninstall"
-    echo "NVM_DIR is not set or directory does not exist: $nvm_dir"
+    echo "Directory does not exist or was not created by this plugin: $nvm_dir"
 fi


### PR DESCRIPTION
## Background
Internal reference: p1741144567645319-slack-C020Q0Z579V

We have noticed a bug where some of our agents gradually were running out of space.
After an investigation in the CI agents, I saw that some had their `/tmp/` directory full of `automattic-nvm-*` folders that were never deleted.

## Investigation

After a deeper investigation in some builds, I noticed the issue happened when multiple jobs running concurrently used the plugin:
1. [Job 1](https://buildkite.com/automattic/woopay-mobile/builds/101#0190bcd8-5e68-48ee-b35f-c1896dee50f9/168-169): creates NVM install directory and sets it in the `meta-data`
1. [Job 2](https://buildkite.com/automattic/woopay-mobile/builds/101#0190bcd8-5e7f-4d19-a57a-de4586b8a5a6/168-169): creates another directory and also sets it in the `meta-data`, overriding the one set in Job 1
1. [Job 3](https://buildkite.com/automattic/woopay-mobile/builds/101#0190bcd8-5e8b-44dc-91ab-5bb484d05287/217-218): creates another directory and also sets it in the `meta-data`, overriding the one set by previous jobs
1. [Job 1](https://buildkite.com/automattic/woopay-mobile/builds/101#0190bcd8-5e68-48ee-b35f-c1896dee50f9/281-282) continues running and finishes, but tries to delete whatever **Job 3** set, which doesn't exist (as it's another agent)
1. [Job 2](https://buildkite.com/automattic/woopay-mobile/builds/101#0190bcd8-5e7f-4d19-a57a-de4586b8a5a6/266-267) also continues running and finishes, but tries to delete whatever **Job 3** set, which doesn't exist (as it's another agent)
1. [Job 3](https://buildkite.com/automattic/woopay-mobile/builds/101#0190bcd8-5e8b-44dc-91ab-5bb484d05287/570-571) finishes and deletes the NVM directory successfully...
1. ...but the agents for **Job 1** and **Job 2** both finish the build without deleting their NVM directory.

## The fix

The fix is simple: we stop using `buildkite-agent meta-data set` and started using a deterministic directory based on the Buildkite Job ID.

To fully test it, I'll create a new release and have it tested in one of the projects where I could simulate the issue.