### PR TITLE
Fix NVM path issues on macOS

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -14,8 +14,11 @@ echo "~~~ :node: Installing nvm"
     return
 }
 
+# Get the system temp directory, defaulting to /tmp if TMPDIR is not set
+tmpdir="${TMPDIR:-/tmp}"
+
 # Use a deterministic directory path based on BUILDKITE_JOB_ID
-NVM_DIR="${TMPDIR:-/tmp}/automattic-nvm-${BUILDKITE_JOB_ID}"
+NVM_DIR="${tmpdir%/}/automattic-nvm/${BUILDKITE_JOB_ID}"
 mkdir -p "$NVM_DIR"
 
 # Make sure the path is a real path, to support scripts in macOS that source $NVM_DIR.

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,8 +2,19 @@
 
 set -euo pipefail
 
+[[ -z "${IS_VM_HOST:-}" ]] || {
+    echo "No need to uninstall nvm on the host, skipping nvm removal"
+    return
+}
+
+# Get the system temp directory, defaulting to /tmp if TMPDIR is not set
+tmpdir="${TMPDIR:-/tmp}"
+
 # Use the same deterministic directory path as in pre-command
-nvm_dir="${TMPDIR:-/tmp}/automattic-nvm-${BUILDKITE_JOB_ID}"
+nvm_dir="${tmpdir%/}/automattic-nvm/${BUILDKITE_JOB_ID}"
+
+# Make sure the path is a real path, just like in pre-command
+nvm_dir=$(readlink -fn "$nvm_dir")
 
 if [[ -d "$nvm_dir" ]]; then
     echo "~~~ :node: Uninstalling Node.js"


### PR DESCRIPTION
While adopting `5.0.0`, I've noticed it didn't seem to work properly only on `mac` agents ([example](https://buildkite.com/automattic/woopay-mobile/builds/103#01956ae2-64b7-4f13-af60-258db68ae80b/8559-8560)).
The hooks are called for the host and the VM. One of the hooks works as expected, the other one logged that it didn't remove the NVM installation folder. Also, there was a double `//` in the path, and the fact that we didn't use `readlink` to reach the real path on `pre-exit` made the code seem inconsistent.

This PR:
- Groups the nvm installs under `automattic-nvm/$BUILDKITE_JOB_ID` (as suggested by @AliSoftware in another PR)
- Adds to `pre-exit` the same check on `IS_VM_HOST` found in `pre-command`, otherwise the logs on the host side will get confusing
- Removes trailing `/` from `TMPDIR` (I've seen it happen on macOS; it eventually still seemed to work in the end, but I was confused by the logs and decided to strip it for the dir string)
- Uses the same `readlink` to generate the directory to be deleted in `pre-exit` as in `pre-command`

A successful build using this branch, successfully removing the nvm directory and skipping the remove attempt on the macOS host: https://buildkite.com/automattic/woopay-mobile/builds/117