### PR TITLE
Release version `0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 0.6.0
+
+### Bug Fixes
+
+* Fix NVM path issues on macOS ensuring proper cleanup [#22]
+
 ## 0.5.0
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - automattic/nvm#0.5.0:
+      - automattic/nvm#0.6.0:
           version: 'v18'
 ```
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+[[ -f .nvmrc || -n "${BUILDKITE_PLUGIN_NVM_VERSION:-}" ]] || {
+    echo "No .nvmrc or Node.js version specified, skipping nvm installation"
+    return
+}
+
 [[ -z "${IS_VM_HOST:-}" ]] || {
     echo "No need to uninstall nvm on the host, skipping nvm removal"
     return


### PR DESCRIPTION
## 0.6.0

### Bug Fixes

* Fix NVM path issues on macOS ensuring proper cleanup; group NVM installs under same directory [#22]