### PR TITLE
Add nvm install timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ The Node.js version [that nvm supports](https://github.com/nvm-sh/nvm#nvmrc). If
 
 Content of [a `.curlrc` file](https://curl.se/docs/manpage.html#-K). This option can be used to pass extra command line arguments to _all curl commands_. For example `--http1.1` makes nvm–which invokes curl commands—use HTTP1.1 protocol.
 
+### `install-timeout-seconds` (Optional, integer)
+
+Maximum number of seconds to allow `nvm install` to run before terminating it.
+Defaults to `1800`.
+Use `0` to disable the timeout.
+
+### `heartbeat-seconds` (Optional, integer)
+
+Number of seconds between progress messages while `nvm install` is still running.
+Defaults to `60`.
+Use `0` to disable heartbeat messages.
+
 ## Contributing
 
 1. Fork the repo

--- a/hooks/lib/nvm-buildkite-plugin.bash
+++ b/hooks/lib/nvm-buildkite-plugin.bash
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+nvm_plugin_read_seconds() {
+    local env_name="$1"
+    local default_value="$2"
+    local label="$3"
+    local value="${!env_name:-$default_value}"
+
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+        echo "Invalid ${label}: ${value}. Expected a non-negative integer." >&2
+        return 1
+    fi
+
+    echo "$value"
+}
+
+nvm_plugin_timestamp() {
+    date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null || echo "unknown-time"
+}
+
+nvm_plugin_log() {
+    printf '[nvm-buildkite-plugin] %s %s\n' "$(nvm_plugin_timestamp)" "$*"
+}
+
 nvm_plugin_should_normalize_windows_pwd() {
     local shell_name="$1"
     local current_pwd="$2"
@@ -47,4 +69,115 @@ nvm_plugin_normalize_windows_pwd_for_nvm() {
         echo "Failed to normalize Windows PWD for nvm to ${normalized_pwd}"
         return 0
     }
+}
+
+nvm_plugin_descendant_pids() {
+    local root_pid="$1"
+
+    if [[ -z "$root_pid" ]] || ! command -v ps >/dev/null 2>&1; then
+        return 0
+    fi
+
+    ps -ef 2>/dev/null | awk -v root_pid="$root_pid" '
+        NR > 1 {
+            pid = $2
+            ppid = $3
+            children[ppid] = children[ppid] " " pid
+        }
+
+        function print_descendants(parent, descendants, child_index, child) {
+            split(children[parent], descendants, " ")
+            for (child_index in descendants) {
+                child = descendants[child_index]
+                if (child != "") {
+                    print child
+                    print_descendants(child)
+                }
+            }
+        }
+
+        END {
+            print_descendants(root_pid)
+        }
+    ' || true
+}
+
+nvm_plugin_terminate_process_tree() {
+    local description="$1"
+    local command_pid="$2"
+    local descendant_pids=""
+    local remaining_descendant_pids=""
+
+    descendant_pids="$(nvm_plugin_descendant_pids "$command_pid" | tr '\n' ' ')"
+    nvm_plugin_log "${description} descendant pids before SIGTERM: ${descendant_pids:-none}" >&2
+    nvm_plugin_log "Sending SIGTERM to ${description} pid=${command_pid}" >&2
+
+    if [[ -n "$descendant_pids" ]]; then
+        # shellcheck disable=SC2086
+        kill -TERM $descendant_pids 2>/dev/null || true
+    fi
+
+    kill -TERM "$command_pid" 2>/dev/null || true
+    sleep 10
+
+    remaining_descendant_pids="$(nvm_plugin_descendant_pids "$command_pid" | tr '\n' ' ')"
+    nvm_plugin_log "${description} descendant pids before SIGKILL: ${remaining_descendant_pids:-none}" >&2
+    nvm_plugin_log "Sending SIGKILL to ${description} pid=${command_pid}" >&2
+
+    if [[ -n "$remaining_descendant_pids" ]]; then
+        # shellcheck disable=SC2086
+        kill -KILL $remaining_descendant_pids 2>/dev/null || true
+    fi
+
+    kill -KILL "$command_pid" 2>/dev/null || true
+}
+
+nvm_plugin_run_with_timeout() {
+    local description="$1"
+    local timeout_seconds="$2"
+    local heartbeat_seconds="$3"
+    shift 3
+
+    if [[ "$timeout_seconds" == "0" && "$heartbeat_seconds" == "0" ]]; then
+        nvm_plugin_log "Running ${description} without timeout or heartbeat"
+        "$@"
+        return
+    fi
+
+    nvm_plugin_log "Starting ${description}; timeout=${timeout_seconds}s heartbeat=${heartbeat_seconds}s"
+    "$@" &
+    local command_pid="$!"
+    local start_seconds="$SECONDS"
+    local elapsed_seconds=0
+    local next_heartbeat_seconds="$heartbeat_seconds"
+    nvm_plugin_log "${description} pid=${command_pid}"
+
+    while kill -0 "$command_pid" 2>/dev/null; do
+        elapsed_seconds=$((SECONDS - start_seconds))
+
+        if [[ "$timeout_seconds" != "0" && "$elapsed_seconds" -ge "$timeout_seconds" ]]; then
+            echo "ERROR: ${description} timed out after ${timeout_seconds}s" >&2
+            nvm_plugin_terminate_process_tree "$description" "$command_pid"
+            break
+        fi
+
+        if [[ "$heartbeat_seconds" != "0" && "$elapsed_seconds" -ge "$next_heartbeat_seconds" ]]; then
+            nvm_plugin_log "${description} still running after ${elapsed_seconds}s; pid=${command_pid}"
+            next_heartbeat_seconds=$((next_heartbeat_seconds + heartbeat_seconds))
+        fi
+
+        sleep 1
+    done
+
+    local status=0
+    if wait "$command_pid"; then
+        status=0
+    else
+        status="$?"
+    fi
+
+    elapsed_seconds=$((SECONDS - start_seconds))
+    nvm_plugin_log "${description} exited with status ${status} after ${elapsed_seconds}s"
+
+    return "$status"
 }

--- a/hooks/lib/nvm-buildkite-plugin.bash
+++ b/hooks/lib/nvm-buildkite-plugin.bash
@@ -181,3 +181,16 @@ nvm_plugin_run_with_timeout() {
 
     return "$status"
 }
+
+nvm_plugin_run_nvm_install_with_timeout() {
+    local timeout_seconds="$1"
+    local heartbeat_seconds="$2"
+    shift 2
+
+    # shellcheck disable=SC2016
+    nvm_plugin_run_with_timeout "nvm install" "$timeout_seconds" "$heartbeat_seconds" bash -c '
+set -e
+source "$NVM_DIR/nvm.sh" --no-use
+nvm install "$@"
+' nvm-install "$@"
+}

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -54,7 +54,10 @@ if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
 else
     echo "Installing Node.js version specified in the .nvmrc file"
 fi
-nvm install "${install_args[@]}"
+
+install_timeout_seconds="$(nvm_plugin_read_seconds BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS 1800 install-timeout-seconds)"
+heartbeat_seconds="$(nvm_plugin_read_seconds BUILDKITE_PLUGIN_NVM_HEARTBEAT_SECONDS 60 heartbeat-seconds)"
+nvm_plugin_run_with_timeout "nvm install" "$install_timeout_seconds" "$heartbeat_seconds" nvm install "${install_args[@]}"
 
 echo "~~~ :node: Activating Node.js"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -57,7 +57,7 @@ fi
 
 install_timeout_seconds="$(nvm_plugin_read_seconds BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS 1800 install-timeout-seconds)"
 heartbeat_seconds="$(nvm_plugin_read_seconds BUILDKITE_PLUGIN_NVM_HEARTBEAT_SECONDS 60 heartbeat-seconds)"
-nvm_plugin_run_with_timeout "nvm install" "$install_timeout_seconds" "$heartbeat_seconds" nvm install "${install_args[@]}"
+nvm_plugin_run_nvm_install_with_timeout "$install_timeout_seconds" "$heartbeat_seconds" "${install_args[@]}"
 
 echo "~~~ :node: Activating Node.js"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,4 +6,10 @@ configuration:
   properties:
     version:
       type: string
+    install-timeout-seconds:
+      type: integer
+      minimum: 0
+    heartbeat-seconds:
+      type: integer
+      minimum: 0
   additionalProperties: false

--- a/tests/nvm-plugin-helpers-test.sh
+++ b/tests/nvm-plugin-helpers-test.sh
@@ -11,6 +11,25 @@ fail() {
     exit 1
 }
 
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+
+    [[ "$actual" == "$expected" ]] || fail "expected '$expected', got '$actual'"
+}
+
+assert_contains() {
+    local needle="$1"
+    local file="$2"
+
+    grep -F "$needle" "$file" >/dev/null || fail "expected '$file' to contain '$needle'"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+assert_equals 1800 "$(nvm_plugin_read_seconds MISSING_TIMEOUT 1800 install-timeout-seconds)"
+
 nvm_plugin_should_normalize_windows_pwd "MSYS_NT-10.0" 'C:\buildkite-agent\repo' || fail "MSYS backslash PWD should be normalized"
 nvm_plugin_should_normalize_windows_pwd "CYGWIN_NT-10.0" 'C:/buildkite-agent/repo' || fail "Cygwin drive PWD should be normalized"
 
@@ -21,5 +40,73 @@ fi
 if nvm_plugin_should_normalize_windows_pwd "linux-gnu" 'C:\buildkite-agent\repo'; then
     fail "non-Windows shell PWD should not be normalized"
 fi
+
+export BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS=12
+assert_equals 12 "$(nvm_plugin_read_seconds BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS 1800 install-timeout-seconds)"
+
+export BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS=abc
+if nvm_plugin_read_seconds BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS 1800 install-timeout-seconds >"$tmpdir/invalid.out" 2>"$tmpdir/invalid.err"; then
+    fail "invalid timeout value should fail"
+fi
+assert_contains "Invalid install-timeout-seconds" "$tmpdir/invalid.err"
+unset BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS
+
+mkdir -p "$tmpdir/fake-bin"
+cat > "$tmpdir/fake-bin/ps" <<'PS'
+#!/usr/bin/env bash
+if [[ "$*" == "-ef" ]]; then
+    cat <<'OUTPUT'
+UID        PID  PPID  C STIME TTY          TIME CMD
+buildkit   100     1  0 00:00 ?        00:00:00 /usr/bin/bash hook
+buildkit   101   100  0 00:00 ?        00:00:00 /usr/bin/bash child
+buildkit   102   101  0 00:00 ?        00:00:00 /usr/bin/bash grandchild
+buildkit   103   100  0 00:00 ?        00:00:00 /usr/bin/curl download
+buildkit   200     1  0 00:00 ?        00:00:00 /usr/bin/bash unrelated
+OUTPUT
+else
+    exit 1
+fi
+PS
+chmod +x "$tmpdir/fake-bin/ps"
+
+PATH="$tmpdir/fake-bin:$PATH" nvm_plugin_descendant_pids 100 >"$tmpdir/descendants.out"
+assert_contains "101" "$tmpdir/descendants.out"
+assert_contains "102" "$tmpdir/descendants.out"
+assert_contains "103" "$tmpdir/descendants.out"
+if grep -F "200" "$tmpdir/descendants.out" >/dev/null; then
+    fail "descendant pids should not include unrelated processes"
+fi
+
+(
+    kill() {
+        echo "kill $*" >> "$tmpdir/kill.log"
+    }
+
+    sleep() {
+        echo "sleep $*" >> "$tmpdir/sleep.log"
+    }
+
+    PATH="$tmpdir/fake-bin:$PATH" nvm_plugin_terminate_process_tree "fake command" 100 >"$tmpdir/terminate.out" 2>"$tmpdir/terminate.err"
+)
+assert_contains "fake command descendant pids before SIGTERM" "$tmpdir/terminate.err"
+assert_contains "fake command descendant pids before SIGKILL" "$tmpdir/terminate.err"
+assert_contains "kill -TERM" "$tmpdir/kill.log"
+assert_contains "kill -KILL" "$tmpdir/kill.log"
+assert_contains "100" "$tmpdir/kill.log"
+assert_contains "101" "$tmpdir/kill.log"
+assert_contains "102" "$tmpdir/kill.log"
+assert_contains "103" "$tmpdir/kill.log"
+
+if ! nvm_plugin_run_with_timeout "quick command" 5 0 bash -c 'exit 0'; then
+    fail "quick command should pass"
+fi
+
+if nvm_plugin_run_with_timeout "slow command" 1 0 bash -c 'sleep 10' >"$tmpdir/timeout.out" 2>"$tmpdir/timeout.err"; then
+    fail "slow command should time out"
+fi
+assert_contains "slow command timed out after 1s" "$tmpdir/timeout.err"
+
+nvm_plugin_run_with_timeout "heartbeat command" 5 1 bash -c 'sleep 2' >"$tmpdir/heartbeat.out"
+assert_contains "heartbeat command still running after 1s" "$tmpdir/heartbeat.out"
 
 echo "All helper tests passed."

--- a/tests/nvm-plugin-helpers-test.sh
+++ b/tests/nvm-plugin-helpers-test.sh
@@ -109,4 +109,29 @@ assert_contains "slow command timed out after 1s" "$tmpdir/timeout.err"
 nvm_plugin_run_with_timeout "heartbeat command" 5 1 bash -c 'sleep 2' >"$tmpdir/heartbeat.out"
 assert_contains "heartbeat command still running after 1s" "$tmpdir/heartbeat.out"
 
+unset -f nvm 2>/dev/null || true
+mkdir -p "$tmpdir/fake-nvm"
+cat > "$tmpdir/fake-nvm/nvm.sh" <<'NVM'
+nvm() {
+    case "$1" in
+        install)
+            shift
+            echo "fake child nvm install $*"
+            touch "$NVM_DIR/installed"
+            ;;
+        *)
+            echo "unsupported nvm command: $*" >&2
+            return 1
+            ;;
+    esac
+}
+NVM
+
+export NVM_DIR="$tmpdir/fake-nvm"
+nvm_plugin_run_nvm_install_with_timeout 5 0 --no-progress 20.19.5 >"$tmpdir/child-install.out"
+assert_contains "fake child nvm install --no-progress 20.19.5" "$tmpdir/child-install.out"
+[[ -f "$tmpdir/fake-nvm/installed" ]] || fail "child nvm install should create installed marker"
+
+unset NVM_DIR
+
 echo "All helper tests passed."

--- a/tests/pre-command-smoke-test.sh
+++ b/tests/pre-command-smoke-test.sh
@@ -52,6 +52,8 @@ echo "20.19.5" > "$tmpdir/work/.nvmrc"
 (
     export PATH="$tmpdir/bin:$PATH"
     export BUILDKITE_JOB_ID="pre-command-smoke"
+    export BUILDKITE_PLUGIN_NVM_INSTALL_TIMEOUT_SECONDS=5
+    export BUILDKITE_PLUGIN_NVM_HEARTBEAT_SECONDS=0
     export TMPDIR="$tmpdir/tmp"
     mkdir -p "$TMPDIR"
 


### PR DESCRIPTION
Stacked on #24.

Adds optional timeout and heartbeat controls around nvm install:

- install-timeout-seconds bounds how long nvm install can run before the plugin terminates it.
- heartbeat-seconds emits periodic progress messages while nvm install is still running.
- Timeout handling terminates descendant processes before returning failure.

This is intentionally separate from the Windows PWD normalization fix because it mitigates future hangs but does not address that root cause.

Validation:
- make test
- shellcheck hooks/pre-command hooks/lib/nvm-buildkite-plugin.bash tests/nvm-plugin-helpers-test.sh tests/pre-command-smoke-test.sh .buildkite/verify_node.sh
- ruby YAML parse for .buildkite/pipeline.yml and plugin.yml
- buildkite-agent pipeline upload --dry-run
- git diff --check