### PR TITLE
Run nvm install in a child shell

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -54,7 +54,13 @@ if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
 else
     echo "Installing Node.js version specified in the .nvmrc file"
 fi
-nvm install "${install_args[@]}"
+# Windows agents hang after checksum validation when `nvm install` runs in the parent hook shell.
+# Running it in a fresh child shell that re-sources nvm gets past the hang.
+bash -c '
+set -e
+source "$NVM_DIR/nvm.sh" --no-use
+nvm install "$@"
+' nvm-install "${install_args[@]}"
 
 echo "~~~ :node: Activating Node.js"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then


### PR DESCRIPTION
## Why

Build [112](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/112) (#24 HEAD) shows the Windows explicit-version jobs (`v20.19.5`, `v24.15.0`) still hang after `Checksums matched!`, while the `.nvmrc` fallback job passes. So #24's `PWD` normalization fixes the `.nvmrc` path (the Beeper case) but leaves a residual hang on the explicit-version path.

Build [104](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/104) — the stacked #25 — cleared those same Windows jobs in 9s. But #25 bundles the child-shell execution together with timeout/heartbeat/process-tree machinery, so it doesn't isolate the cause.

This PR changes **one thing**: it runs `nvm install` in a fresh child `bash` that re-sources `nvm.sh`, with none of #25's timeout machinery. If the Windows explicit-version jobs pass here, the child shell — not the timeout — is the fix.

## How to test

Watch this branch's Buildkite run. The `.nvmrc` Windows job should stay green (normalization intact) and both explicit-version Windows jobs should now clear `Checksums matched!` and finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
