### PR TITLE
Normalize PWD after sourcing nvm

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,10 +41,10 @@ echo "Installing nvm in $NVM_DIR"
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash
 
-nvm_plugin_normalize_windows_pwd_for_nvm
-
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use
+
+nvm_plugin_normalize_windows_pwd_for_nvm
 
 echo "~~~ :node: Installing Node.js"
 install_args=("--no-progress")


### PR DESCRIPTION
## Why

Follow-up to the dead-end #26. Across builds, the only change separating the last all-green build ([104](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/104) — normalization **after** `source nvm.sh`) from every build that hangs the explicit-version Windows jobs ([111](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/111)/[112](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/112)/[113](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/113) — normalization **before**) is commit `e00aea8`, which moved normalization before the source.

This PR reverts only that reorder — a single-variable test against build 112. If the explicit-version Windows jobs (`v20.19.5`, `v24.15.0`) pass here, the before-source ordering is the cause.

## Tradeoff to check

`e00aea8`'s before-source ordering is what reportedly fixed Beeper's `.nvmrc` Windows hang. This repo's `.nvmrc` Windows job passed in build 104 with the after-source ordering, but the Beeper downstream needs re-checking before this lands.

## How to test

Watch this branch's Buildkite run. Success = both explicit-version Windows jobs clear `Checksums matched!` and finish, and the `.nvmrc` Windows job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
