### PR TITLE
Normalize after source and install in child shell

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,10 +41,10 @@ echo "Installing nvm in $NVM_DIR"
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash
 
-nvm_plugin_normalize_windows_pwd_for_nvm
-
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use
+
+nvm_plugin_normalize_windows_pwd_for_nvm
 
 echo "~~~ :node: Installing Node.js"
 install_args=("--no-progress")
@@ -54,7 +54,13 @@ if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
 else
     echo "Installing Node.js version specified in the .nvmrc file"
 fi
-nvm install "${install_args[@]}"
+# Windows agents hang after checksum validation when `nvm install` runs in the parent hook shell.
+# Running it in a fresh child shell that re-sources nvm gets past the hang.
+bash -c '
+set -e
+source "$NVM_DIR/nvm.sh" --no-use
+nvm install "$@"
+' nvm-install "${install_args[@]}"
 
 echo "~~~ :node: Activating Node.js"
 if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then


### PR DESCRIPTION
## Why

#26 (child-shell only) and #27 (after-source only) each hung — but the 2×2 across all builds shows neither change fixes the explicit-version Windows hang *alone*. The only green run, build [104](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/104), had **both**:

| normalize | install | explicit-version Windows |
|---|---|---|
| after source | child shell | ✅ 104 |
| before source | child shell | ❌ 113 (#26) |
| before source | parent | ❌ 112 |
| after source | parent | ❌ 114 (#27) |

This PR reproduces 104's winning combination on current HEAD. Build 104 also used the older cygpath-era normalization helper; this branch uses the pure-bash one, so a green run also rules the helper version out as a factor.

## How to test

Watch this branch's Buildkite run. Success = both explicit-version Windows jobs (`v20.19.5`, `v24.15.0`) clear `Checksums matched!` and finish, and the `.nvmrc` Windows job stays green. If green, both changes fold into #24 as the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
