### PR TITLE
Experiment: explicit-version Windows jobs with .nvmrc present

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,8 +25,13 @@ steps:
           - mac
           - default
 
+  # EXPERIMENT: same explicit-version Windows jobs that hang, but with a .nvmrc
+  # generated in the working directory. If these pass, .nvmrc presence is what
+  # prevents the post-checksum hang on the explicit-version path.
   - label: ":windows: :node: Validate {{ matrix.node }} on Windows"
     command: bash .buildkite/verify_node.sh {{ matrix.node }}
+    env:
+      NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION: "{{ matrix.node }}"
     plugins:
       - automattic/nvm#${BUILDKITE_COMMIT}:
           version: "{{ matrix.node }}"


### PR DESCRIPTION
## Experiment (not for merge)

Confirms the verified root cause: the explicit-version Windows jobs hang because no `.nvmrc` is in the working directory. Build [104](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/104) only passed because a `.nvmrc` was committed at the repo root then; removing it (correctly) exposed the hang on the `version:`-property path.

This adds `NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION` to the *existing hanging* explicit-version jobs so the repo hook writes a `.nvmrc` before the plugin runs — the single variable separating 104 from 112–115.

**Expected:** both `v20.19.5` and `v24.15.0` Windows jobs pass. If so, `.nvmrc` presence is the gate, and the real bug is `nvm install <explicit version>` hanging on Windows when no `.nvmrc` is in the directory tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
