### PR TITLE
Spike: bump nvm to v0.40.5, drop normalization

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -39,9 +39,10 @@ fi
 
 echo "Installing nvm in $NVM_DIR"
 
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | PROFILE=/dev/null bash
 
-nvm_plugin_normalize_windows_pwd_for_nvm
+# SPIKE: normalization removed to test whether nvm v0.40.5 handles the Windows
+# backslash PWD natively. Restore if the Windows jobs hang.
 
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use


### PR DESCRIPTION
## Spike (not for merge)

Tests whether bumping nvm `v0.39.4 → v0.40.5` fixes the Windows hang at its source. Root cause: the Jun 26 AMI bump (Elastic CI Stack v6.67.0) ships bash 5.3.9, and nvm v0.39.4's directory walk loops under it after `Checksums matched!`.

Normalization is removed in the same spike so the Windows jobs run on the raw backslash PWD. Two signals in one build:

- **`.nvmrc` fallback on Windows** (backslash PWD + `.nvmrc`, no normalization) → tests trigger 1 (the Beeper case).
- **explicit-version jobs** (backslash PWD, no `.nvmrc`) → tests triggers 1 + 2.

**If all Windows jobs pass:** v0.40.5 handles both natively → single clean fix, drop normalization. **If anything hangs:** restore normalization + layer the `.nvmrc`-in-cwd mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
