### PR TITLE
Diagnostic: print PWD before nvm install

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,31 +41,28 @@ echo "Installing nvm in $NVM_DIR"
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | PROFILE=/dev/null bash
 
+# DIAGNOSTIC v3 (temporary): bisect where the Windows hang is. A padding block
+# fills the stdio buffer (which never flushes while the process hangs), forcing
+# a flush BEFORE each risky step so a later hang can't erase earlier readings.
+# Search the log for "[diag]". The last [diag] STAGE seen pinpoints the hang.
+diag_flush() { awk 'BEGIN { for (i = 0; i < 4000; i++) print "[pad] flush " i }'; }
+diag_trim_noop() { [ "${PWD%/*}" = "$PWD" ] && echo YES || echo NO; }
+
+printf '[diag] STAGE raw: PWD=%s trim-noop=%s\n' "$PWD" "$(diag_trim_noop)"
+printf '[diag] STAGE about-to-normalize\n'
+diag_flush
+
 nvm_plugin_normalize_windows_pwd_for_nvm
+printf '[diag] STAGE normalized: PWD=%s trim-noop=%s\n' "$PWD" "$(diag_trim_noop)"
+printf '[diag] STAGE about-to-source\n'
+diag_flush
 
 # shellcheck source=/dev/null
 source "$NVM_DIR/nvm.sh" --no-use
+printf '[diag] STAGE sourced-ok\n'
+diag_flush
 
-echo "~~~ :node: Installing Node.js"
-install_args=("--no-progress")
-if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
-    echo "Installing Node.js version ${BUILDKITE_PLUGIN_NVM_VERSION}"
-    install_args+=("${BUILDKITE_PLUGIN_NVM_VERSION}")
-else
-    echo "Installing Node.js version specified in the .nvmrc file"
-fi
-# DIAGNOSTIC (temporary): nvm_find_project_dir loops forever when `${PWD%/*}`
-# can't strip a trailing segment (a pure-backslash Windows PWD). Buffered hook
-# output never flushes while the process hangs, so report the verdict and
-# `return` BEFORE the real install — the hook exits and Buildkite flushes this.
-printf '[diag] PWD=%s\n' "$PWD"
-printf '[diag] pwd=%s\n' "$(pwd)"
-printf '[diag] one-trim=%s\n' "${PWD%/*}"
-if [ "${PWD%/*}" = "$PWD" ]; then
-    printf '[diag] VERDICT: trim is a NO-OP -> nvm_find_project_dir would loop forever here\n'
-else
-    printf '[diag] VERDICT: trim shrinks PWD -> walk terminates; hang is elsewhere\n'
-fi
+printf '[diag] STAGE all-clear: neither normalize nor source hung\n'
 return 0
 
 nvm install "${install_args[@]}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -54,6 +54,13 @@ if [[ -n ${BUILDKITE_PLUGIN_NVM_VERSION:-} ]]; then
 else
     echo "Installing Node.js version specified in the .nvmrc file"
 fi
+# DIAGNOSTIC (temporary): nvm_find_project_dir loops forever when `${PWD%/*}`
+# can't strip a trailing segment (a pure-backslash Windows PWD). Print to stderr
+# so it flushes before any hang. `one-trim` equal to `PWD` proves the no-op loop.
+printf '[diag] PWD=%s\n' "$PWD" >&2
+printf '[diag] pwd=%s\n' "$(pwd)" >&2
+printf '[diag] one-trim=%s\n' "${PWD%/*}" >&2
+
 nvm install "${install_args[@]}"
 
 echo "~~~ :node: Activating Node.js"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -55,11 +55,18 @@ else
     echo "Installing Node.js version specified in the .nvmrc file"
 fi
 # DIAGNOSTIC (temporary): nvm_find_project_dir loops forever when `${PWD%/*}`
-# can't strip a trailing segment (a pure-backslash Windows PWD). Print to stderr
-# so it flushes before any hang. `one-trim` equal to `PWD` proves the no-op loop.
-printf '[diag] PWD=%s\n' "$PWD" >&2
-printf '[diag] pwd=%s\n' "$(pwd)" >&2
-printf '[diag] one-trim=%s\n' "${PWD%/*}" >&2
+# can't strip a trailing segment (a pure-backslash Windows PWD). Buffered hook
+# output never flushes while the process hangs, so report the verdict and
+# `return` BEFORE the real install — the hook exits and Buildkite flushes this.
+printf '[diag] PWD=%s\n' "$PWD"
+printf '[diag] pwd=%s\n' "$(pwd)"
+printf '[diag] one-trim=%s\n' "${PWD%/*}"
+if [ "${PWD%/*}" = "$PWD" ]; then
+    printf '[diag] VERDICT: trim is a NO-OP -> nvm_find_project_dir would loop forever here\n'
+else
+    printf '[diag] VERDICT: trim shrinks PWD -> walk terminates; hang is elsewhere\n'
+fi
+return 0
 
 nvm install "${install_args[@]}"
 


### PR DESCRIPTION
## Diagnostic (not for merge)

Settles the one open question: does PR #24's normalization actually give nvm a forward-slash `$PWD` on the explicit-version Windows path? The explicit jobs hang in `nvm_find_project_dir`, whose `${path_%/*}` loop never terminates on a pure-backslash PWD.

Prints `$PWD`, `pwd`, and `${PWD%/*}` to **stderr** (so it flushes before the hang swallows block-buffered stdout) right before `nvm install`. Read on the hung `v20.19.5` / `v24.15.0` Windows jobs:

- `one-trim` **equals** `PWD` → backslash no-op loop; normalization didn't stick → fix normalization.
- `one-trim` **shorter** than `PWD` → forward-slash; normalization stuck → the hang is elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
