### PR TITLE
Write .nvmrc for explicit-version Windows CI jobs

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,8 +5,6 @@
 
 set -euo pipefail
 
-if [[ -z "${NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION:-}" ]]; then
-    exit 0
+if [[ -n "${NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION:-}" ]]; then
+    printf '%s\n' "$NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION" > .nvmrc
 fi
-
-printf '%s\n' "$NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION" > .nvmrc

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,12 @@ steps:
 
   - label: ":windows: :node: Validate {{ matrix.node }} on Windows"
     command: bash .buildkite/verify_node.sh {{ matrix.node }}
+    env:
+      # nvm v0.39.4 hangs on the Windows agent when no .nvmrc exists in the
+      # working directory: its ancestor walk for one loops forever under the
+      # agent's bash. The version property below still drives the install; this
+      # .nvmrc only exists to short-circuit that walk.
+      NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION: "{{ matrix.node }}"
     plugins:
       - automattic/nvm#${BUILDKITE_COMMIT}:
           version: "{{ matrix.node }}"


### PR DESCRIPTION
## Why

The explicit-version Windows jobs (`v20.19.5`, `v24.15.0`) hang and get killed (exit `0xC000013A`) — not an assertion failure, a genuine hang. With **no `.nvmrc` in the working directory**, nvm `v0.39.4`'s ancestor walk (`nvm_find_project_dir`) loops forever under the Windows agent's bash. The `.nvmrc`-fallback Windows job passes precisely because it *has* a `.nvmrc`.

This is a CI-harness problem, not a plugin one: the plugin's `version:`-property path is fine — real consumers that ship a `.nvmrc` never hit the walk. So the fix stays in CI.

Setting `NVM_BUILDKITE_PLUGIN_TEST_NVMRC_VERSION` on the explicit-version jobs makes the repo `pre-command` hook write a `.nvmrc` before the plugin runs, short-circuiting the walk. The plugin still installs via the `version:` property; the `.nvmrc` is only a decoy for nvm's directory search.

No change to `hooks/` or `plugin.yml`.

## How to test

Watch the two explicit-version Windows jobs (`v20.19.5`, `v24.15.0`) go green. This configuration already passed end-to-end in [build 116](https://buildkite.com/automattic/nvm-buildkite-plugin/builds/116) (the #29 experiment); this PR lands it as the minimal, clean change.
