### PR TITLE
Fail fast when Windows PWD cannot be normalized

### DIFF
--- a/hooks/lib/nvm-buildkite-plugin.bash
+++ b/hooks/lib/nvm-buildkite-plugin.bash
@@ -66,18 +66,19 @@ nvm_plugin_resolve_normalized_pwd() {
 }
 
 nvm_plugin_normalize_windows_pwd_for_nvm() {
-    local shell_name
+    local shell_name current_pwd
     shell_name="$(uname -s 2>/dev/null || true)"
+    current_pwd="${PWD:-}"
 
     local normalized_pwd
-    if ! normalized_pwd="$(nvm_plugin_resolve_normalized_pwd "$shell_name" "${PWD:-}")"; then
-        echo "Cannot normalize Windows PWD for nvm from ${PWD}; refusing to continue so nvm does not hang" >&2
+    if ! normalized_pwd="$(nvm_plugin_resolve_normalized_pwd "$shell_name" "$current_pwd")"; then
+        echo "Cannot normalize Windows PWD for nvm from ${current_pwd}; refusing to continue so nvm does not hang" >&2
         return 1
     fi
 
     [[ -n "$normalized_pwd" ]] || return 0
 
-    echo "Normalizing Windows PWD for nvm from ${PWD} to ${normalized_pwd}"
+    echo "Normalizing Windows PWD for nvm from ${current_pwd} to ${normalized_pwd}"
     cd "$normalized_pwd" || {
         echo "Cannot enter normalized Windows PWD ${normalized_pwd} for nvm; refusing to continue so nvm does not hang" >&2
         return 1

--- a/hooks/lib/nvm-buildkite-plugin.bash
+++ b/hooks/lib/nvm-buildkite-plugin.bash
@@ -46,33 +46,40 @@ nvm_plugin_windows_pwd_to_posix() {
     esac
 }
 
+# Echoes the POSIX directory nvm should run in for the given shell and PWD.
+# Returns 0 with no output when no normalization is needed. Returns non-zero
+# when the PWD needs normalizing but a usable target can't be produced — the
+# caller must treat that as fatal, since letting nvm run on the un-normalized
+# PWD is the hang this helper exists to avoid.
+nvm_plugin_resolve_normalized_pwd() {
+    local shell_name="$1"
+    local current_pwd="$2"
+
+    nvm_plugin_should_normalize_windows_pwd "$shell_name" "$current_pwd" || return 0
+
+    local normalized_pwd
+    normalized_pwd="$(nvm_plugin_windows_pwd_to_posix "$current_pwd")" || return 1
+    [[ -n "$normalized_pwd" && "$normalized_pwd" != "$current_pwd" ]] || return 1
+    [[ -d "$normalized_pwd" ]] || return 1
+
+    printf '%s\n' "$normalized_pwd"
+}
+
 nvm_plugin_normalize_windows_pwd_for_nvm() {
     local shell_name
     shell_name="$(uname -s 2>/dev/null || true)"
 
-    if ! nvm_plugin_should_normalize_windows_pwd "$shell_name" "${PWD:-}"; then
-        return 0
-    fi
-
     local normalized_pwd
-    if ! normalized_pwd="$(nvm_plugin_windows_pwd_to_posix "$PWD")"; then
-        echo "Cannot normalize Windows PWD for nvm from ${PWD}"
-        return 0
+    if ! normalized_pwd="$(nvm_plugin_resolve_normalized_pwd "$shell_name" "${PWD:-}")"; then
+        echo "Cannot normalize Windows PWD for nvm from ${PWD}; refusing to continue so nvm does not hang" >&2
+        return 1
     fi
 
-    if [[ -z "$normalized_pwd" || "$normalized_pwd" == "$PWD" ]]; then
-        echo "Cannot normalize Windows PWD for nvm from ${PWD}"
-        return 0
-    fi
-
-    if [[ ! -d "$normalized_pwd" ]]; then
-        echo "Cannot normalize Windows PWD for nvm because ${normalized_pwd} is not a directory"
-        return 0
-    fi
+    [[ -n "$normalized_pwd" ]] || return 0
 
     echo "Normalizing Windows PWD for nvm from ${PWD} to ${normalized_pwd}"
     cd "$normalized_pwd" || {
-        echo "Failed to normalize Windows PWD for nvm to ${normalized_pwd}"
-        return 0
+        echo "Cannot enter normalized Windows PWD ${normalized_pwd} for nvm; refusing to continue so nvm does not hang" >&2
+        return 1
     }
 }

--- a/tests/nvm-plugin-helpers-test.sh
+++ b/tests/nvm-plugin-helpers-test.sh
@@ -30,4 +30,22 @@ if nvm_plugin_windows_pwd_to_posix "/c/buildkite-agent/repo" >/dev/null; then
     fail "POSIX path should not be converted"
 fi
 
+# nvm_plugin_resolve_normalized_pwd: no normalization needed -> success, no output.
+[[ -z "$(nvm_plugin_resolve_normalized_pwd "linux-gnu" 'C:\buildkite-agent\repo')" ]] || fail "non-Windows shell should resolve to no normalization"
+[[ -z "$(nvm_plugin_resolve_normalized_pwd "MSYS_NT-10.0" "/c/buildkite-agent/repo")" ]] || fail "POSIX PWD should resolve to no normalization"
+
+# A PWD that needs normalizing and points at a real directory resolves to it.
+real_dir="$(mktemp -d)"
+trap 'rm -rf "$real_dir"' EXIT
+resolved="$(nvm_plugin_resolve_normalized_pwd "MSYS_NT-10.0" "\\${real_dir//\//\\}")" || fail "resolvable Windows PWD should not fail"
+[[ -n "$resolved" && -d "$resolved" ]] || fail "resolvable Windows PWD should be normalized to an existing directory"
+
+# A PWD that needs normalizing but cannot be resolved must fail, not fall through.
+if nvm_plugin_resolve_normalized_pwd "MSYS_NT-10.0" 'relative\path' >/dev/null; then
+    fail "unconvertible Windows PWD should fail rather than resolve"
+fi
+if nvm_plugin_resolve_normalized_pwd "MSYS_NT-10.0" 'C:\does\not\exist' >/dev/null; then
+    fail "Windows PWD pointing at a missing directory should fail rather than resolve"
+fi
+
 echo "All helper tests passed."

--- a/tests/nvm-plugin-helpers-test.sh
+++ b/tests/nvm-plugin-helpers-test.sh
@@ -35,6 +35,8 @@ fi
 [[ -z "$(nvm_plugin_resolve_normalized_pwd "MSYS_NT-10.0" "/c/buildkite-agent/repo")" ]] || fail "POSIX PWD should resolve to no normalization"
 
 # A PWD that needs normalizing and points at a real directory resolves to it.
+# The input is the tmp dir as a UNC path: a leading "\\" plus the dir with its
+# slashes flipped to backslashes, which nvm_plugin_windows_pwd_to_posix converts back.
 real_dir="$(mktemp -d)"
 trap 'rm -rf "$real_dir"' EXIT
 resolved="$(nvm_plugin_resolve_normalized_pwd "MSYS_NT-10.0" "\\${real_dir//\//\\}")" || fail "resolvable Windows PWD should not fail"


### PR DESCRIPTION
## Why

Follow-up to @iangmaia's review comment on #24: https://github.com/Automattic/nvm-buildkite-plugin/pull/24#discussion_r3497351578

Fails early if then normalized PWD is invalid

<details>
<summary>AI-generated details</summary>


Once `nvm_plugin_should_normalize_windows_pwd` says a PWD needs normalizing, that PWD is precisely the kind that makes nvm's slash-trimming directory walk loop forever. The previous helper logged and returned success on every path that couldn't produce a usable normalized directory, so `hooks/pre-command` carried on into `nvm install` on the bad PWD — the exact hang the helper exists to prevent. Now those paths fail, aborting the hook under `set -euo pipefail` with a clear reason.

## Gotcha

This is a behavior change: a Windows job whose PWD can't be normalized now fails fast instead of hanging until the agent timeout. That's the intended trade — a legible error beats a wedged agent.

## How to test

`make test` — the decision is extracted into `nvm_plugin_resolve_normalized_pwd` (injectable on shell name and PWD) so the fail-fast branches are unit-tested off Windows. The Windows `cd` success path is still exercised by the `:windows:` jobs in CI.


</details>